### PR TITLE
use upstream release

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1331,9 +1331,10 @@ resources:
 - name: logsearch-for-cloudfoundry-release
   type: s3-iam
   source:
-    bucket: ((cg-s3-bosh-releases-bucket))
+    bucket: logsearch
     regexp: logsearch-for-cloudfoundry-(.*).tgz
-    region_name: ((aws-region))
+    region_name: us-east-1
+    private: false
 
 - name: oauth2-proxy-release
   type: s3-iam

--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -211,6 +211,17 @@ instance_groups:
         source_files: [/var/vcap/jobs/kibana-auth-plugin/config/config.sh]
         health:
           timeout: 600
+        config_options:
+          "xpack.searchprofiler.enabled": false
+          "xpack.grokdebugger.enabled": false
+          "xpack.apm.ui.enabled": false
+          # set reporting key for load balanced scenarios
+          # "xpack.reporting.encryptionKey": secret
+          "xpack.monitoring.enabled": false
+          "xpack.graph.enabled": false
+          "xpack.ml.enabled": false
+          "xpack.security.enabled": false
+          "xpack.watcher.enabled": false
   - name: kibana-auth-plugin
     release: logsearch-for-cloudfoundry
     properties:

--- a/logsearch-platform-jobs.yml
+++ b/logsearch-platform-jobs.yml
@@ -177,6 +177,17 @@ instance_groups:
         - NODE_ENV: production
         health:
           timeout: 600
+        config_options:
+          "xpack.searchprofiler.enabled": false
+          "xpack.grokdebugger.enabled": false
+          "xpack.apm.ui.enabled": false
+          # set reporting key for load balanced scenarios
+          # "xpack.reporting.encryptionKey": secret
+          "xpack.monitoring.enabled": false
+          "xpack.graph.enabled": false
+          "xpack.ml.enabled": false
+          "xpack.security.enabled": false
+          "xpack.watcher.enabled": false
   - name: oauth2-proxy
     release: oauth2-proxy
     properties:

--- a/secrets.example.yml
+++ b/secrets.example.yml
@@ -8,6 +8,8 @@ instance_groups:
       kibana:
         env:
         - KIBANA_OAUTH2_CLIENT_SECRET:
+        config_options:
+          "xpack.reporting.encryptionKey":
 
 - name: ingestor
   jobs:
@@ -42,3 +44,4 @@ instance_groups:
         syslog:
           host: 127.0.0.1
           port: 514 
+


### PR DESCRIPTION
We're only ahead of cloudfoundry-community/logsearch-for-cloudfoundry by commits about xpack and object-ids. This PR should get us off our fork and using theirs.

WIP because I think it's probably smart to get to about the same spot for logsearch-boshrelease first