### PR TITLE
remove jobs that have no hope of working without significant work

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -21,13 +21,10 @@ groups:
     - smoke-tests-production
     - smoke-tests-login-production
     - deploy-logsearch-platform-development
-    - upload-kibana-objects-platform-development
     - smoke-tests-platform-development
     - deploy-logsearch-platform-staging
-    - upload-kibana-objects-platform-staging
     - smoke-tests-platform-staging
     - deploy-logsearch-platform-production
-    - upload-kibana-objects-platform-production
     - smoke-tests-platform-production
   - name: tenant-development
     jobs:
@@ -40,7 +37,6 @@ groups:
     jobs:
     - deploy-logsearch-platform-development
     - smoke-tests-platform-development
-    - upload-kibana-objects-platform-development
     - check-backup-development-platform
   - name: tenant-staging
     jobs:
@@ -53,7 +49,6 @@ groups:
     jobs:
     - deploy-logsearch-platform-staging
     - smoke-tests-platform-staging
-    - upload-kibana-objects-platform-staging
     - check-backup-staging-platform
   - name: tenant-production
     jobs:
@@ -66,7 +61,6 @@ groups:
     jobs:
     - deploy-logsearch-platform-production
     - smoke-tests-platform-production
-    - upload-kibana-objects-platform-production
     - check-backup-production-platform
   - name: tenant
     jobs:
@@ -89,15 +83,12 @@ groups:
     jobs:
     - deploy-logsearch-platform-development
     - smoke-tests-platform-development
-    - upload-kibana-objects-platform-development
     - check-backup-development-platform
     - deploy-logsearch-platform-staging
     - smoke-tests-platform-staging
-    - upload-kibana-objects-platform-staging
     - check-backup-staging-platform
     - deploy-logsearch-platform-production
     - smoke-tests-platform-production
-    - upload-kibana-objects-platform-production
     - check-backup-production-platform
 
 jobs:
@@ -254,26 +245,6 @@ jobs:
       text: |
         :white_check_mark: Smoke tests for platform logsearch on development PASSED
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-
-- name: upload-kibana-objects-platform-development
-  serial_groups: [bosh-platform-development]
-  plan:
-  - in_parallel:
-    - get: common
-      resource: master-bosh-root-cert
-    - get: pipeline-tasks
-    - get: logsearch-platform-development-deployment
-      trigger: true
-      passed: [deploy-logsearch-platform-development]
-  - task: upload-kibana-objects
-    file: pipeline-tasks/bosh-errand.yml
-    params:
-      BOSH_ENVIRONMENT: ((bosh.development.environment))
-      BOSH_CLIENT: ((bosh.development.client))
-      BOSH_CLIENT_SECRET: ((bosh.development.client-secret))
-      BOSH_DEPLOYMENT: ((logsearch-platform.development.name))
-      BOSH_CA_CERT: common/master-bosh.crt
-      BOSH_ERRAND: upload-kibana-objects
 
 - name: deploy-logsearch-development
   serial_groups: [bosh-development]
@@ -617,26 +588,6 @@ jobs:
         :white_check_mark: Smoke tests for platform logsearch on staging PASSED
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
 
-- name: upload-kibana-objects-platform-staging
-  serial_groups: [bosh-platform-staging]
-  plan:
-  - in_parallel:
-    - get: common
-      resource: master-bosh-root-cert
-    - get: pipeline-tasks
-      passed: [deploy-logsearch-platform-staging]
-    - get: logsearch-platform-staging-deployment
-      trigger: true
-  - task: upload-kibana-objects
-    file: pipeline-tasks/bosh-errand.yml
-    params:
-      BOSH_ENVIRONMENT: ((bosh.staging.environment))
-      BOSH_CLIENT: ((bosh.staging.client))
-      BOSH_CLIENT_SECRET: ((bosh.staging.client-secret))
-      BOSH_DEPLOYMENT: ((logsearch-platform.staging.name))
-      BOSH_CA_CERT: common/master-bosh.crt
-      BOSH_ERRAND: upload-kibana-objects
-
 - name: deploy-logsearch-staging
   serial_groups: [bosh-staging]
   plan:
@@ -977,26 +928,6 @@ jobs:
       text: |
         :white_check_mark: Smoke tests for platform logsearch on production PASSED
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-
-- name: upload-kibana-objects-platform-production
-  serial_groups: [bosh-platform-production]
-  plan:
-  - in_parallel:
-    - get: common
-      resource: master-bosh-root-cert
-    - get: pipeline-tasks
-    - get: logsearch-platform-production-deployment
-      passed: [deploy-logsearch-platform-production]
-      trigger: true
-  - task: upload-kibana-objects
-    file: pipeline-tasks/bosh-errand.yml
-    params:
-      BOSH_ENVIRONMENT: ((bosh.production.environment))
-      BOSH_CLIENT: ((bosh.production.client))
-      BOSH_CLIENT_SECRET: ((bosh.production.client-secret))
-      BOSH_DEPLOYMENT: ((logsearch-platform.production.name))
-      BOSH_CA_CERT: common/master-bosh.crt
-      BOSH_ERRAND: upload-kibana-objects
 
 - name: deploy-logsearch-production
   serial_groups: [bosh-production]


### PR DESCRIPTION
## Changes proposed in this pull request:
- remove upload objects jobs for platform jobs. They don't work, and most likely will look entirely different whenever we make them work.

## security considerations
None