### PR TITLE
remove recreate=true on logsearch bosh deploy as it seems unnecessary

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -304,7 +304,6 @@ jobs:
       - prometheus-release/*.tgz
       stemcells:
       - logsearch-stemcell-xenial/*.tgz
-      recreate: true
   on_failure:
     put: slack
     params: &slack-params


### PR DESCRIPTION
## Changes proposed in this pull request:

The logsearch deploy currently recreates all vms on every deployment. This seems time-consuming and unnecessary so we are removing this.

## security considerations

none
