### PR TITLE
move the total_fields limit to the correct job

### DIFF
--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -97,6 +97,10 @@ instance_groups:
         - index-mappings-platform-lfc: /var/vcap/jobs/elasticsearch-config-lfc/index-mappings-platform.json
   - name: elasticsearch-config-lfc
     release: logsearch-for-cloudfoundry
+    properties:
+      elasticsearch_config:
+        app_index_settings:
+          index.mapping.total_fields.limit: 2000
   - name: elasticsearch_exporter
     release: prometheus
     properties:
@@ -104,9 +108,7 @@ instance_groups:
         es:
           uri: http://localhost:9200
           all: true
-        elasticsearch_config:
-          app_index_settings:
-            index.mapping.total_fields.limit: 2000
+          
   - name: upload-kibana-objects
     release: logsearch-for-cloudfoundry
     consumes:


### PR DESCRIPTION
## Changes proposed in this pull request:

Moves the total_fields config to the correct job as per: https://github.com/cloud-gov/logsearch-for-cloudfoundry/blob/7c68f7878fd3aba64f2910f25f85bb2789c35d4d/jobs/elasticsearch-config-lfc/spec#L29

## security considerations

None
