### PR TITLE
move console disabling from config_options to dedicated property

### DIFF
--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -213,8 +213,7 @@ instance_groups:
         default_app_id: "dashboard/App-Overview"
         plugins:
         - auth: /var/vcap/packages/kibana-auth-plugin/kibana-auth-plugin.zip
-        config_options: 
-          console.enabled: false
+        console_enabled: false
         env:
         - NODE_ENV: production
         source_files: [/var/vcap/jobs/kibana-auth-plugin/config/config.sh]


### PR DESCRIPTION
## Changes proposed in this pull request:

Changes the `console.enabled` property setting from `config_options` to the dedicated property for the Kibana job.

## security considerations

none
