### PR TITLE
try to get 2 version 7 data nodes

### DIFF
--- a/logsearch-development.yml
+++ b/logsearch-development.yml
@@ -11,6 +11,8 @@ instance_groups:
 - name: elasticsearch_data
   instances: 4
   vm_type: t3.medium
+  update:
+    max_in_flight: 2
 
 - name: maintenance
   vm_type: t3.medium


### PR DESCRIPTION
## Changes proposed in this pull request:

I have been unable to update the cluster b/c there is only a single version 7 of the data nodes (I think). I am hoping to get to two data nodes to get past this update.

## security considerations

None
