### PR TITLE
V211

### DIFF
--- a/logsearch-development.yml
+++ b/logsearch-development.yml
@@ -9,11 +9,8 @@ instance_groups:
     - (( grab terraform_outputs.logsearch_static_ips.[0]))
 
 - name: elasticsearch_data
-  instances: 4
+  instances: 3
   vm_type: t3.medium
-  update:
-    max_in_flight: 2
-    canaries: 2
 
 - name: maintenance
   vm_type: t3.medium

--- a/logsearch-platform-development.yml
+++ b/logsearch-platform-development.yml
@@ -32,6 +32,9 @@ instance_groups:
 - name: elasticsearch_data
   instances: 3
   vm_type: t3.medium
+  update:
+    max_in_flight: 2
+    canaries: 2
 
 - name: redis
   instances: 1


### PR DESCRIPTION
## Changes proposed in this pull request:

- Removes the canary and max_in_flight setting from logs-development data nodes as the v7 upgrade is done
- Overrides the canary and max_in_flight settings for logs-platform-development data nodes so the cluster can upgrade to v7

## security considerations

None
