### PR TITLE
temporarily disable health check for scale out

### DIFF
--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -177,6 +177,7 @@ instance_groups:
           fd: 131072  # 2 ** 17
         health:
           timeout: 900
+          disable_post_start: true
         recovery:
           delay_allocation_restart: "15m"
         migrate_data_path: true


### PR DESCRIPTION
## Changes proposed in this pull request:
- This disables the post-start health check on data nodes. This is intended to be a temporary change to allow the scale out to go through

## security considerations
None