### PR TITLE
Undo swap_size adjustment for logsearch platform

### DIFF
--- a/logsearch-platform-jobs.yml
+++ b/logsearch-platform-jobs.yml
@@ -40,9 +40,6 @@ instance_groups:
     - (( grab terraform_outputs.logsearch_static_ips.[9]))
   update:
     max_in_flight: 1 # Should never update more than one ES master node at a time or cluster will go down
-  env:
-    bosh:
-      swap_size: 0
 
 - name: redis
   instances: 1
@@ -164,9 +161,6 @@ instance_groups:
   - name: services
   update:
     max_in_flight: 1 # Only update 1 ES data node at a time or risk downtime
-  env:
-    bosh:
-      swap_size: 0
 
 - name: kibana
   instances: 2
@@ -215,9 +209,6 @@ instance_groups:
   azs: [z1]
   networks:
   - name: services
-  env:
-    bosh:
-      swap_size: 0
 
 - name: ingestor
   instances: 5


### PR DESCRIPTION
This changeset reverts a previous change that shut off use of the swap file.  That change only mattered for `es_data` and there are no performance concerns on logs-platform.  To maintain system stability, we are removing these changes.

## Changes proposed in this pull request:
- Remove `swap_size` additions from earlier

## security considerations
None
