### PR TITLE
v7 upgrade. ready for prod

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1291,7 +1291,6 @@ resources:
   type: git
   source:
     uri: ((cg-deploy-logsearch-git-url))
-    branch: upgrade-to-v7
 
 - name: logsearch-stemcell-xenial
   type: bosh-io-stemcell

--- a/logsearch-deployment.yml
+++ b/logsearch-deployment.yml
@@ -22,3 +22,4 @@ releases:
 - {name: cf, version: latest}
 - {name: snort, version: latest}
 - {name: cron, version: latest}
+- {name: bpm, version: latest}

--- a/logsearch-development.yml
+++ b/logsearch-development.yml
@@ -14,6 +14,14 @@ instance_groups:
 
 - name: maintenance
   vm_type: t3.medium
+  instances: 1
+  jobs:
+  - name: curator
+    release: logsearch
+    properties:
+      curator:
+        purge_logs:
+          retention_period: 90
 
 - name: redis
   instances: 1
@@ -38,7 +46,7 @@ instance_groups:
         api_endpoint: https://api.dev.us-gov-west-1.aws-us-gov.cloud.gov
 
 - name: kibana
-  vm_type: t3.medium
+  vm_type: t3.large
   instances: 1
   jobs:
   - name: kibana-auth-plugin

--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -5,6 +5,8 @@ instance_groups:
 - name: elasticsearch_master
   instances: 3
   jobs:
+  - name: bpm
+    release: bpm
   - name: elasticsearch
     release: logsearch
     provides:
@@ -55,6 +57,8 @@ instance_groups:
 - name: redis
   instances: 1
   jobs:
+  - name: bpm
+    release: bpm
   - {name: redis, release: logsearch-for-cloudfoundry}
   persistent_disk_type: logsearch_redis
   stemcell: default
@@ -66,6 +70,8 @@ instance_groups:
   instances: 1
   vm_extensions: [errand-profile]
   jobs:
+  - name: bpm
+    release: bpm
   - name: elasticsearch
     release: logsearch
     consumes:
@@ -76,16 +82,12 @@ instance_groups:
   - name: curator
     release: logsearch
     # nil the link and use the colocated instance when https://github.com/cloudfoundry-community/logsearch-boshrelease/pull/90 is merged
-    consumes:
-      elasticsearch: {from: elasticsearch_master}
     properties:
       curator:
         purge_logs:
           retention_period: 180
   - name: elasticsearch_config
     release: logsearch
-    consumes:
-      elasticsearch: {from: elasticsearch_master}
     properties:
       elasticsearch_config:
         templates:
@@ -112,8 +114,6 @@ instance_groups:
           
   - name: upload-kibana-objects
     release: logsearch-for-cloudfoundry
-    consumes:
-      elasticsearch: {from: elasticsearch_master}
     properties:
       cloudfoundry:
         firehose_events:
@@ -125,7 +125,6 @@ instance_groups:
       kibana_objects:
         upload_patterns:
         - {type: index-pattern, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/index-pattern/*.json"}
-        - {type: config, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/config/*.json"}
         - {type: search, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/search/app-*.json"}
         - {type: visualization, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/visualization/App-*.json"}
         - {type: dashboard, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/dashboard/App-*.json"}
@@ -161,6 +160,8 @@ instance_groups:
 - name: elasticsearch_data
   instances: 9
   jobs:
+  - name: bpm
+    release: bpm
   - name: elasticsearch
     release: logsearch
     consumes:
@@ -177,7 +178,6 @@ instance_groups:
           fd: 131072  # 2 ** 17
         health:
           timeout: 900
-          disable_post_start: true
         recovery:
           delay_allocation_restart: "15m"
         migrate_data_path: true
@@ -195,6 +195,8 @@ instance_groups:
 - name: kibana
   instances: 2
   jobs:
+  - name: bpm
+    release: bpm
   - name: elasticsearch
     release: logsearch
     consumes:
@@ -205,6 +207,8 @@ instance_groups:
         migrate_data_path: true
   - name: kibana
     release: logsearch
+    provides:
+      kibana: {as: kibana_link}
     consumes:
       elasticsearch: {from: elasticsearch_master}
     properties:
@@ -252,6 +256,8 @@ instance_groups:
 
 - name: archiver
   jobs:
+  - name: bpm
+    release: bpm
   - name: elasticsearch
     release: logsearch
     consumes:
@@ -301,6 +307,8 @@ instance_groups:
 
 - name: ingestor
   jobs:
+  - name: bpm
+    release: bpm
   - name: elasticsearch
     release: logsearch
     consumes:
@@ -313,6 +321,8 @@ instance_groups:
     release: logsearch
     consumes:
       elasticsearch: {from: elasticsearch_master}
+    provides:
+      ingestor: {as: ingestor_link}
     properties:
       logstash:
         queue:
@@ -367,3 +377,4 @@ instance_groups:
     release: logsearch
     consumes:
       elasticsearch: {from: elasticsearch_master}
+      ingestor_link: {from: ingestor_syslog}

--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -81,7 +81,6 @@ instance_groups:
         migrate_data_path: true
   - name: curator
     release: logsearch
-    # nil the link and use the colocated instance when https://github.com/cloudfoundry-community/logsearch-boshrelease/pull/90 is merged
     properties:
       curator:
         purge_logs:

--- a/logsearch-platform-deployment.yml
+++ b/logsearch-platform-deployment.yml
@@ -21,3 +21,4 @@ releases:
 - {name: prometheus, version: latest}
 - {name: oauth2-proxy, version: latest}
 - {name: secureproxy, version: latest}
+- {name: bpm, version: latest}

--- a/logsearch-platform-development.yml
+++ b/logsearch-platform-development.yml
@@ -18,7 +18,7 @@ instance_groups:
           retention_period: 7
 
 - name: kibana
-  vm_type: t3.medium
+  vm_type: t3.large
   instances: 1
   jobs:
   - name: oauth2-proxy

--- a/logsearch-platform-jobs.yml
+++ b/logsearch-platform-jobs.yml
@@ -5,6 +5,8 @@ instance_groups:
 - name: elasticsearch_master
   instances: 3
   jobs:
+  - name: bpm
+    release: bpm
   - name: elasticsearch
     release: logsearch
     provides:
@@ -44,6 +46,8 @@ instance_groups:
 - name: redis
   instances: 1
   jobs:
+  - name: bpm
+    release: bpm
   - {name: redis, release: logsearch-for-cloudfoundry}
   vm_type: logsearch_redis
   persistent_disk_type: logsearch_redis
@@ -56,6 +60,8 @@ instance_groups:
   instances: 1
   vm_extensions: [errand-profile]
   jobs:
+  - name: bpm
+    release: bpm
   - name: elasticsearch
     release: logsearch
     consumes:
@@ -67,16 +73,12 @@ instance_groups:
         migrate_data_path: true
   - name: curator
     release: logsearch
-    consumes:
-      elasticsearch: {from: elasticsearch_master}
     properties:
       curator:
         purge_logs:
           retention_period: 30
   - name: elasticsearch_config
     release: logsearch
-    consumes:
-      elasticsearch: {from: elasticsearch_master}
     properties:
       elasticsearch_config:
         app_index_prefix: logs-platform
@@ -101,8 +103,6 @@ instance_groups:
           index.mapping.total_fields.limit: 2000
   - name: upload-kibana-objects
     release: logsearch-for-cloudfoundry
-    consumes:
-      elasticsearch: {from: elasticsearch_master}
     properties:
       elasticsearch_config:
         app_index_prefix: logs-platform
@@ -110,12 +110,12 @@ instance_groups:
         system_domain: (( grab $CF_SYSTEM_DOMAIN ))
         user: (( grab $CF_USERNAME ))
         password: (( grab $CF_PASSWORD ))
+        logs_hostname: logs-platform
       kibana_objects:
         host_name: logs-platform
         login_fqdn: opslogin.fr.cloud.gov
         upload_patterns:
         - {type: index-pattern, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/index-pattern/*.json"}
-        - {type: config, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/config/*.json"}
         - {type: search, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/search/platform-*.json"}
         - {type: visualization, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/visualization/Platform-*.json"}
         - {type: dashboard, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/dashboard/Platform-*.json"}
@@ -133,6 +133,8 @@ instance_groups:
 - name: elasticsearch_data
   instances: 9
   jobs:
+  - name: bpm
+    release: bpm
   - name: elasticsearch
     release: logsearch
     consumes:
@@ -165,6 +167,8 @@ instance_groups:
 - name: kibana
   instances: 2
   jobs:
+  - name: bpm
+    release: bpm
   - name: elasticsearch
     release: logsearch
     consumes:
@@ -177,6 +181,8 @@ instance_groups:
     release: logsearch
     consumes:
       elasticsearch: {from: elasticsearch_master}
+    provides:
+      kibana: {as: kibana_link}
     properties:
       kibana:
         port: 5602
@@ -213,6 +219,8 @@ instance_groups:
 - name: ingestor
   instances: 5
   jobs:
+  - name: bpm
+    release: bpm
   - name: elasticsearch
     release: logsearch
     consumes:
@@ -226,6 +234,8 @@ instance_groups:
     release: logsearch
     consumes: 
       elasticsearch: {from: elasticsearch_master}
+    provides:
+      ingestor: {as: ingestor_link}
     properties:
       logstash:
         queue:
@@ -285,3 +295,4 @@ instance_groups:
     release: logsearch
     consumes:
       elasticsearch: {from: elasticsearch_master}
+      ingestor_link: {from: ingestor_syslog}

--- a/logsearch-platform-production.yml
+++ b/logsearch-platform-production.yml
@@ -6,7 +6,7 @@ instance_groups:
   vm_type: t3.large
 
 - name: kibana
-  vm_type: t3.large
+  vm_type: t3.xlarge
   jobs:
   - name: oauth2-proxy
     properties:
@@ -23,6 +23,9 @@ instance_groups:
 
 - name: elasticsearch_data
   vm_type: r5.xlarge
+  update:
+    max_in_flight: 2
+    canaries: 2
 
 - name: redis
   instances: 1

--- a/logsearch-platform-staging.yml
+++ b/logsearch-platform-staging.yml
@@ -4,7 +4,7 @@ instance_groups:
 
 - name: elasticsearch_data
   instances: 4
-  vm_type: t3.medium
+  vm_type: t3.large
 
 - name: redis
   vm_type: r5.large
@@ -16,7 +16,7 @@ instance_groups:
   vm_type: t3.large
 
 - name: kibana
-  vm_type: t3.large
+  vm_type: t3.xlarge
   jobs:
   - name: oauth2-proxy
     properties:

--- a/logsearch-production.yml
+++ b/logsearch-production.yml
@@ -4,6 +4,9 @@ instance_groups:
 
 - name: elasticsearch_data
   vm_type: r5.2xlarge
+  update:
+    max_in_flight: 2
+    canaries: 2
 
 - name: maintenance
   vm_type: t3.large
@@ -30,7 +33,7 @@ instance_groups:
         api_endpoint: https://api.fr.cloud.gov
 
 - name: kibana
-  vm_type: t3.large
+  vm_type: t3.xlarge
   jobs:
   - name: kibana-auth-plugin
     properties:

--- a/logsearch-staging.yml
+++ b/logsearch-staging.yml
@@ -5,6 +5,9 @@ instance_groups:
 - name: elasticsearch_data
   instances: 3
   vm_type: t3.large
+  update:
+    max_in_flight: 2
+    canaries: 2
 
 - name: maintenance
   vm_type: t3.medium
@@ -31,7 +34,7 @@ instance_groups:
         api_endpoint: https://api.fr-stage.cloud.gov
 
 - name: kibana
-  vm_type: t3.large
+  vm_type: t3.xlarge
   jobs:
   - name: kibana-auth-plugin
     properties:


### PR DESCRIPTION
## Changes proposed in this pull request:

- Upgrades from 6.8.1 to 7.6.1 
- Prepares for a logs in staging, logs in production, and logs-platform in production deployment (data node canaries = 2 to satisfy quorum).

## security considerations

Closes an open POAM.
