### PR TITLE
Remove update block from staging

### DIFF
--- a/logsearch-staging.yml
+++ b/logsearch-staging.yml
@@ -5,9 +5,6 @@ instance_groups:
 - name: elasticsearch_data
   instances: 3
   vm_type: t3.xlarge
-  update:
-    max_in_flight: 2
-    canaries: 2
 
 - name: maintenance
   vm_type: t3.medium


### PR DESCRIPTION
This changeset removes the update block `elasticsearch_data` nodes as it is no longer needed.  We needed 2 canaries and 2 in flight to ensure the new 7.6.1 cluster would hit quorum. Once updated, we do not need this anymore.

h/t to @spgreenberg for the help with this!

## Changes proposed in this pull request:
- Removes the update block from the `elasticsearch_data` nodes

## Security considerations
- None; just an update to infrastructure configuration that is already shared publicly