### PR TITLE
move max query clause to es masters

### DIFF
--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -29,6 +29,8 @@ instance_groups:
           timeout: 900
         recovery:
           delay_allocation_restart: "15m"
+        config_options: 
+          indices.query.bool.max_clause_count: 2048
   - name: snort-config
     release: snort
     properties:
@@ -103,7 +105,6 @@ instance_groups:
         app_index_settings:
           index.mapping.total_fields.limit: 2000
           index.queries.cache.enabled: "false"
-          indices.query.bool.max_clause_count: 2048
   - name: elasticsearch_exporter
     release: prometheus
     properties:


### PR DESCRIPTION
## Changes proposed in this pull request:

Move query indices setting to elastic search masters as per: https://github.com/cloud-gov/logsearch-boshrelease/blob/a6a69a42237516e0abc8c2fcbed5222e0f4f2aa6/jobs/elasticsearch/spec#L118

## security considerations

none
