### PR TITLE
fix counting in backup script

### DIFF
--- a/ci/check-backup.sh
+++ b/ci/check-backup.sh
@@ -8,7 +8,7 @@ now=$(date -u)
 
 tempfile=$(mktemp)
 
-log_count=$(curl -s "${ES_HOST}:${ES_PORT:-9200}/${INDEX_PATTERN}/_search?size=0" -H 'Content-Type: application/json' -d @<(cat <<EOF
+log_count=$(curl -s "${ES_HOST}:${ES_PORT:-9200}/${INDEX_PATTERN}/_count" -H 'Content-Type: application/json' -d @<(cat <<EOF
 {
   "query": {
     "range": {
@@ -20,7 +20,7 @@ log_count=$(curl -s "${ES_HOST}:${ES_PORT:-9200}/${INDEX_PATTERN}/_search?size=0
   }
 }
 EOF
-) | jq -r '.hits.total')
+) | jq -r '.count')
 
 cat <<EOF > ${tempfile}
 logsearch_backup_log_count {environment="${ENVIRONMENT}"} ${log_count}


### PR DESCRIPTION
The API for the _search endpoint has changed. The return value now looks
different, confusing this script, and the API only returns up to 10,000
results.
Meanwhile, a _count endpoint has been introduced, which makes this
script faster and more accurate.

## Changes proposed in this pull request:
- Fix the script

## security considerations
None