### PR TITLE
Add missing jobs key to build-releases group

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -29,6 +29,7 @@ groups:
     - deploy-logsearch-platform-production
     - smoke-tests-platform-production
   - name: build-releases
+    jobs:
     - build-logsearch-release
     - build-logsearch-for-cloudfoundry-release
   - name: tenant-development


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add missing `jobs` key in the group

## security considerations
none
