### PR TITLE
Breakout run tests task into job to pass to run build-logsearch-for-cloudfoundry-release

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -158,6 +158,22 @@ jobs:
         args:
           - -exc
           - cd release-git-repo/src/kibana-cf_authentication && npm install && npm test
+  on_failure:
+    put: slack
+    params: &slack-params
+      text: |
+        :x: FAILED to pass tests for the latest update to logsearch-for-cloudfoundry
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+      channel: ((slack-channel))
+      username: ((slack-username))
+      icon_url: ((slack-icon-url))
+  on_success:
+    put: slack
+    params:
+      <<: *slack-params
+      text: |
+        :white_check_mark: Successfully passed tests for the latest update to logsearch-for-cloudfoundry
+        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
 
 - name: build-logsearch-for-cloudfoundry-release
   plan:
@@ -274,13 +290,11 @@ jobs:
       - logsearch-stemcell-xenial/*.tgz
   on_failure:
     put: slack
-    params: &slack-params
+    params:
+      <<: *slack-params
       text: |
         :x: FAILED to deploy platform logsearch on development
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: ((slack-channel))
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
   on_success:
     put: slack
     params:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -157,9 +157,7 @@ jobs:
         path: sh
         args:
           - -exc
-          - cd release-git-repo/src/kibana-cf_authentication &&
-          - npm install &&
-          - npm test
+          - cd release-git-repo/src/kibana-cf_authentication && npm install && npm test
 
 - name: build-logsearch-for-cloudfoundry-release
   plan:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -3,6 +3,7 @@ groups:
   - name: all
     jobs:
     - build-logsearch-release
+    - test-logsearch-for-cloudfoundry-release
     - build-logsearch-for-cloudfoundry-release
     - deploy-logsearch-development
     - upload-kibana-objects-development
@@ -31,6 +32,7 @@ groups:
   - name: build-releases
     jobs:
     - build-logsearch-release
+    - test-logsearch-for-cloudfoundry-release
     - build-logsearch-for-cloudfoundry-release
   - name: tenant-development
     jobs:
@@ -135,17 +137,12 @@ jobs:
       params:
         file: finalized-release/releases-dir-logsearch.tgz
 
-- name: build-logsearch-for-cloudfoundry-release
+- name: test-logsearch-for-cloudfoundry-release
   plan:
   - in_parallel:
     - get: release-git-repo
       resource: logsearch-for-cloudfoundry-release-git-repo
       trigger: true
-    - get: pipeline-tasks
-    - get: final-builds-dir-tarball
-      resource: logsearch-for-cloudfoundry-final-builds-dir-tarball
-    - get: releases-dir-tarball
-      resource: logsearch-for-cloudfoundry-releases-dir-tarball
   - task: run-tests
     config:
       inputs:
@@ -160,7 +157,22 @@ jobs:
         path: sh
         args:
           - -exc
-          - cd release-git-repo/src/kibana-cf_authentication && npm test
+          - cd release-git-repo/src/kibana-cf_authentication &&
+          - npm install &&
+          - npm test
+
+- name: build-logsearch-for-cloudfoundry-release
+  plan:
+  - in_parallel:
+    - get: release-git-repo
+      resource: logsearch-for-cloudfoundry-release-git-repo
+      passed: [test-logsearch-for-cloudfoundry-release]
+      trigger: true
+    - get: pipeline-tasks
+    - get: final-builds-dir-tarball
+      resource: logsearch-for-cloudfoundry-final-builds-dir-tarball
+    - get: releases-dir-tarball
+      resource: logsearch-for-cloudfoundry-releases-dir-tarball
   - task: finalize-release
     file: pipeline-tasks/finalize-bosh-release.yml
     tags: [iaas]


### PR DESCRIPTION
To support more robust testing in https://github.com/cloud-gov/logsearch-for-cloudfoundry, moved the test running task for `build-logsearch-for-cloudfoundry-release` into its own job so we can install devDependencies without adding those to the release.

## Changes proposed in this pull request:
- [X] Remove task for testing from `build-logsearch-for-cloudfoundry-release`
- [X] Create job `test-logsearch-for-cloudfoundry-release` with passing dependency for `build-logsearch-for-cloudfoundry-release`
- [x] Add slack integration on failed task

## security considerations
None
