### PR TITLE
drop unused redis VMs

### DIFF
--- a/logsearch-platform-development.yml
+++ b/logsearch-platform-development.yml
@@ -33,10 +33,6 @@ instance_groups:
   instances: 3
   vm_type: t3.medium
 
-- name: redis
-  instances: 1
-  vm_type: t3.small
-
 - name: smoke-tests
   vm_type: t3.small
   jobs:

--- a/logsearch-platform-jobs.yml
+++ b/logsearch-platform-jobs.yml
@@ -45,19 +45,6 @@ instance_groups:
   update:
     max_in_flight: 1 # Should never update more than one ES master node at a time or cluster will go down
 
-- name: redis
-  instances: 1
-  jobs:
-  - name: bpm
-    release: bpm
-  - {name: redis, release: logsearch-for-cloudfoundry}
-  vm_type: logsearch_redis
-  persistent_disk_type: logsearch_redis
-  stemcell: default
-  azs: [z1]
-  networks:
-  - name: services
-
 - name: maintenance
   instances: 1
   vm_extensions: [errand-profile]

--- a/logsearch-platform-production.yml
+++ b/logsearch-platform-production.yml
@@ -27,10 +27,6 @@ instance_groups:
     max_in_flight: 2
     canaries: 2
 
-- name: redis
-  instances: 1
-  vm_type: t3.medium
-
 - name: smoke-tests
   vm_type: t3.small
   jobs:

--- a/logsearch-platform-staging.yml
+++ b/logsearch-platform-staging.yml
@@ -6,9 +6,6 @@ instance_groups:
   instances: 4
   vm_type: t3.large
 
-- name: redis
-  vm_type: r5.large
-
 - name: ingestor
   vm_type: t3.large
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- drop unused redis VMs. I validated these are unused by checking flow logs in dev and production. This VM has not received a single packet on the redis port in the last week. None of the other jobs reference it either, so it's fine.


## security considerations
Removing unused components reduces attack surface and maintenance burden