### PR TITLE
add platform s3 upload

### DIFF
--- a/logsearch-platform-jobs.yml
+++ b/logsearch-platform-jobs.yml
@@ -271,6 +271,22 @@ instance_groups:
                 }
               }
             }
+        outputs:
+        - plugin: s3
+          options:
+            region: (( grab terraform_outputs.vpc_region ))
+            bucket: (( grab terraform_outputs.platform_logs_bucket_name ))
+            access_key_id: (( grab terraform_outputs.platform_logs_bucket_access_key_id_curr ))
+            secret_access_key: (( grab terraform_outputs.platform_logs_bucket_secret_access_key_curr ))
+            server_side_encryption: true
+            prefix: "%{+yyyy/MM/dd/HH/mm}"
+            encoding: "gzip"
+            temporary_directory: /var/vcap/data/logstash_ingestor/s3_temp
+            # note that this is different than in the archivers
+            # here, we're uploading the parsed message as json, not the raw log line
+            codec: json
+        - plugin: elasticsearch
+          options: {}
         deployment_dictionary:
         - /var/vcap/packages/logsearch-config/deployment_lookup.yml
         - /var/vcap/jobs/parser-config-lfc/config/deployment_lookup.yml


### PR DESCRIPTION
## Changes proposed in this pull request:
- add platform s3 upload. 

One important thing to note: we're emitting files of parsed json when we're done, so this is different from the archiver functionality. Frankly, I did this because it's easier - the existing release expects only simple key/value pairs for the options on plugins, so we have to either send the whole parsed event (what we're doing) or alter the release to support more complex configurations, since emitting just the raw line would require support for something like
```
s3 {
  access_key_id => "key"
  ...
  codec => line {
    format => "%{[@raw]}"
  }
}
```

## security considerations
this reduces the likelihood of us losing all traces of an event, but also means that we have more places that a secret might exist if leaked via logging