### PR TITLE
force merge old indices

### DIFF
--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -84,8 +84,32 @@ instance_groups:
     release: logsearch
     properties:
       curator:
+        execute:
+          daily: true
+          hourly: false
         purge_logs:
           retention_period: 180
+        actions:
+        - action: forcemerge
+          description: >-
+            Force merging of older indices to make their shards more compact
+            and search-optimized
+          options:
+            ignore_empty_list: true
+            max_num_segments: 1
+          filters:
+          - filtertype: pattern
+            kind: regex
+            value: logs*
+          - filtertype: age
+            source: creation_date
+            direction: older
+            unit: days
+            unit_count: 90
+          - filtertype: forcemerged
+            max_num_segments: 1
+            exclude: true
+
   - name: elasticsearch_config
     release: logsearch
     properties:


### PR DESCRIPTION
The main goal here is to start merging old indices. This is an optimization recommended by Elasticsearch to reduce shard overhead and optimize searches.

It sounds pretty safe, but to be extra safe, we'll start with 90+ day old indices to limit the amount folks hit this. I imagine we'll keep this for now, then next Monday switch from 90 to 45, then 45 to 28 about a week later, then 14, then 7 and finally 3 (we don't want less than 3 because we want to be very sure we don't write to force-merged indices)

## Changes proposed in this pull request:
- force merge old indices to make them more compact and optimized. Start only with 90+ day-old indices, since merging is expensive and we want to test on less-used indices first
- switch curator to daily instead of hourly. None of our tasks need to happen more than once a day, and by running daily we can be more sure the expensive hit from force-merge will happen at off-peak times
-

## security considerations
None