### PR TITLE
bump VM type for ES dev to t3.large

### DIFF
--- a/logsearch-platform-development.yml
+++ b/logsearch-platform-development.yml
@@ -1,7 +1,7 @@
 instance_groups:
 - name: elasticsearch_master
   instances: 1
-  vm_type: t3.medium
+  vm_type: t3.large
   networks:
   - name: services
     static_ips:


### PR DESCRIPTION
## Changes proposed in this pull request:

- bump VM type for ES dev to t3.large

## security considerations

None
