### PR TITLE
update VM type for logsearch platform prod

### DIFF
--- a/logsearch-platform-production.yml
+++ b/logsearch-platform-production.yml
@@ -29,7 +29,7 @@ instance_groups:
     canaries: 2
 
 - name: smoke-tests
-  vm_type: t3.small
+  vm_type: t3.medium
   jobs:
   - name: smoke_tests
     properties:


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update VM type for smoke-tests in logsearch platform prod to give memory headroom

## security considerations

None
