### PR TITLE
disable data migration for elasticsearch-platform job in dev and staging

### DIFF
--- a/logsearch-platform-development.yml
+++ b/logsearch-platform-development.yml
@@ -2,6 +2,11 @@ instance_groups:
 - name: elasticsearch_master
   instances: 1
   vm_type: t3.large
+  jobs:
+  - name: elasticsearch-platform
+    properties:
+      elasticsearch:
+        migrate_data: false
   networks:
   - name: services
     static_ips:
@@ -37,6 +42,11 @@ instance_groups:
 - name: elasticsearch_data
   instances: 3
   vm_type: t3.medium
+  jobs:
+  - name: elasticsearch-platform
+    properties:
+      elasticsearch:
+        migrate_data: false
 
 - name: smoke-tests
   vm_type: t3.small

--- a/logsearch-platform-staging.yml
+++ b/logsearch-platform-staging.yml
@@ -1,10 +1,20 @@
 instance_groups:
 - name: elasticsearch_master
   vm_type: t3.large
+  jobs:
+  - name: elasticsearch-platform
+    properties:
+      elasticsearch:
+        migrate_data: false
 
 - name: elasticsearch_data
   instances: 4
   vm_type: t3.large
+  jobs:
+  - name: elasticsearch-platform
+    properties:
+      elasticsearch:
+        migrate_data: false
 
 - name: ingestor
   vm_type: t3.large


### PR DESCRIPTION
## Changes proposed in this pull request:

- Disable data migration from old job data store (`elasticsearch`) to new job name (`elasticsearch-platform`) data store since this is already complete in dev & stage

## security considerations

None

