### PR TITLE
disable data migration & cleanup data in stage

### DIFF
--- a/logsearch-platform-development.yml
+++ b/logsearch-platform-development.yml
@@ -6,7 +6,6 @@ instance_groups:
   - name: elasticsearch-platform
     properties:
       elasticsearch:
-        migrate_data: false
         delete_migrated_data: true
   networks:
   - name: services
@@ -47,7 +46,6 @@ instance_groups:
   - name: elasticsearch-platform
     properties:
       elasticsearch:
-        migrate_data: false
         delete_migrated_data: true
 
 - name: smoke-tests

--- a/logsearch-platform-jobs.yml
+++ b/logsearch-platform-jobs.yml
@@ -27,7 +27,6 @@ instance_groups:
           delay_allocation_restart: "15m"
         jvm_options:
           - "-Dlog4j2.formatMsgNoLookups=true"
-        migrate_data: true
   vm_type: logsearch_es_master
   persistent_disk_type: logsearch_es_master
   stemcell: default
@@ -148,7 +147,6 @@ instance_groups:
         recovery:
           delay_allocation_restart: "15m"
         config_options: {"xpack.monitoring.enabled": false}
-        migrate_data: true
   vm_type: logsearch_es_data
   persistent_disk_type: logsearch_es_platform_data
   stemcell: default

--- a/logsearch-platform-production.yml
+++ b/logsearch-platform-production.yml
@@ -1,6 +1,11 @@
 instance_groups:
 - name: elasticsearch_master
   vm_type: t3.xlarge
+  jobs:
+  - name: elasticsearch-platform
+    properties:
+      elasticsearch:
+        migrate_data: false
 
 - name: maintenance
   vm_type: t3.large
@@ -31,8 +36,7 @@ instance_groups:
     - name: elasticsearch-platform
       properties:
         elasticsearch:
-          health:
-            timeout: 1800
+          migrate_data: false
 
 - name: smoke-tests
   vm_type: t3.medium

--- a/logsearch-platform-production.yml
+++ b/logsearch-platform-production.yml
@@ -1,11 +1,6 @@
 instance_groups:
 - name: elasticsearch_master
   vm_type: t3.xlarge
-  jobs:
-  - name: elasticsearch-platform
-    properties:
-      elasticsearch:
-        migrate_data: false
 
 - name: maintenance
   vm_type: t3.large
@@ -32,11 +27,6 @@ instance_groups:
   update:
     max_in_flight: 2
     canaries: 2
-  jobs:
-    - name: elasticsearch-platform
-      properties:
-        elasticsearch:
-          migrate_data: false
 
 - name: smoke-tests
   vm_type: t3.medium

--- a/logsearch-platform-staging.yml
+++ b/logsearch-platform-staging.yml
@@ -5,7 +5,6 @@ instance_groups:
   - name: elasticsearch-platform
     properties:
       elasticsearch:
-        migrate_data: false
         delete_migrated_data: true
 
 - name: elasticsearch_data
@@ -15,7 +14,6 @@ instance_groups:
   - name: elasticsearch-platform
     properties:
       elasticsearch:
-        migrate_data: false
         delete_migrated_data: true
 
 - name: ingestor

--- a/logsearch-platform-staging.yml
+++ b/logsearch-platform-staging.yml
@@ -6,6 +6,7 @@ instance_groups:
     properties:
       elasticsearch:
         migrate_data: false
+        delete_migrated_data: true
 
 - name: elasticsearch_data
   instances: 4
@@ -15,6 +16,7 @@ instance_groups:
     properties:
       elasticsearch:
         migrate_data: false
+        delete_migrated_data: true
 
 - name: ingestor
   vm_type: t3.large


### PR DESCRIPTION
## Changes proposed in this pull request:

- Disable data migration in logs-platform stage & prod now that all deployments have been upgraded to use `elasticsearch-platform` data store
- Configure logs-platform stage deployment to cleanup old data in `elasticsearch`

## security considerations

None
