### PR TITLE
change tenant logs back to be retained for 180 days in ELK

### DIFF
--- a/logsearch-development.yml
+++ b/logsearch-development.yml
@@ -22,7 +22,6 @@ instance_groups:
       curator:
         purge_logs:
           retention_period: 90
-          unit: days
 
 - name: redis
   instances: 1

--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -88,8 +88,7 @@ instance_groups:
           daily: true
           hourly: false
         purge_logs:
-          retention_period: 12
-          unit: months
+          retention_period: 180
         actions:
         - action: forcemerge
           description: >-


### PR DESCRIPTION
## Changes proposed in this pull request:

- change tenant logs back to be retained for 180 days in ELK

## security considerations

None
