### PR TITLE
update VM type for smoke tests from t3.small to t3.medium

### DIFF
--- a/logsearch-production.yml
+++ b/logsearch-production.yml
@@ -64,7 +64,7 @@ instance_groups:
           query: '*'
 
 - name: smoke-tests
-  vm_type: t3.small
+  vm_type: t3.medium
   jobs:
   - name: smoke_tests
     properties:


### PR DESCRIPTION
## Changes proposed in this pull request:

- update VM type for smoke tests from t3.small to t3.medium to increase memory capacity. We are frequently getting alerts about low memory for this VM

## security considerations

None
