### PR TITLE
fixes indentation for index_settings

### DIFF
--- a/logsearch-platform-jobs.yml
+++ b/logsearch-platform-jobs.yml
@@ -62,24 +62,24 @@ instance_groups:
       curator:
         purge_logs:
           retention_period: 30
-      actions:
-      - action: index_settings
-        description: >-
-          Sets indices older than 1 day to be read only
-        options:
-          index_settings:
-            index:
-              blocks:
-                write: true
-        filters:
-        - filtertype: pattern
-          kind: regex
-          value: logs*
-        - filtertype: age
-          source: creation_date
-          direction: older
-          unit: days
-          unit_count: 1
+        actions:
+        - action: index_settings
+          description: >-
+            Sets indices older than 1 day to be read only
+          options:
+            index_settings:
+              index:
+                blocks:
+                  write: true
+          filters:
+          - filtertype: pattern
+            kind: regex
+            value: logs*
+          - filtertype: age
+            source: creation_date
+            direction: older
+            unit: days
+            unit_count: 1
   - name: elasticsearch_config
     release: logsearch
     properties:


### PR DESCRIPTION
## Changes proposed in this pull request:
- Properly Indents code for platform logs so that setting log indices to read only works properly

## security considerations
None