### PR TITLE
Clean old prod data for original elasticsearch job name

### DIFF
--- a/logsearch-platform-development.yml
+++ b/logsearch-platform-development.yml
@@ -2,11 +2,6 @@ instance_groups:
 - name: elasticsearch_master
   instances: 1
   vm_type: t3.large
-  jobs:
-  - name: elasticsearch-platform
-    properties:
-      elasticsearch:
-        delete_migrated_data: true
   networks:
   - name: services
     static_ips:
@@ -42,11 +37,6 @@ instance_groups:
 - name: elasticsearch_data
   instances: 3
   vm_type: t3.medium
-  jobs:
-  - name: elasticsearch-platform
-    properties:
-      elasticsearch:
-        delete_migrated_data: true
 
 - name: smoke-tests
   vm_type: t3.small

--- a/logsearch-platform-production.yml
+++ b/logsearch-platform-production.yml
@@ -1,6 +1,11 @@
 instance_groups:
 - name: elasticsearch_master
   vm_type: t3.xlarge
+  jobs:
+  - name: elasticsearch-platform
+    properties:
+      elasticsearch:
+        delete_migrated_data: true
 
 - name: maintenance
   vm_type: t3.large
@@ -27,6 +32,11 @@ instance_groups:
   update:
     max_in_flight: 2
     canaries: 2
+  jobs:
+  - name: elasticsearch-platform
+    properties:
+      elasticsearch:
+        delete_migrated_data: true
 
 - name: smoke-tests
   vm_type: t3.medium

--- a/logsearch-platform-staging.yml
+++ b/logsearch-platform-staging.yml
@@ -1,20 +1,10 @@
 instance_groups:
 - name: elasticsearch_master
   vm_type: t3.large
-  jobs:
-  - name: elasticsearch-platform
-    properties:
-      elasticsearch:
-        delete_migrated_data: true
 
 - name: elasticsearch_data
   instances: 4
   vm_type: t3.large
-  jobs:
-  - name: elasticsearch-platform
-    properties:
-      elasticsearch:
-        delete_migrated_data: true
 
 - name: ingestor
   vm_type: t3.large


### PR DESCRIPTION
## Changes proposed in this pull request:

- Configure logsearch-platform prod deployment to cleanup old data in `elasticsearch` now that data has been moved to `elasticsearch-platform`
- Disable data clean up in dev & stage since it has already run

## security considerations

None
