### PR TITLE
bump instance type to r5.xlarge for logsearch prod archiver vms

### DIFF
--- a/logsearch-production.yml
+++ b/logsearch-production.yml
@@ -16,7 +16,7 @@ instance_groups:
 
 - name: archiver
   instances: 3
-  vm_type: r5.large
+  vm_type: r5.xlarge
   jobs:
   - name: ingestor_cloudfoundry-firehose
     properties:


### PR DESCRIPTION
## Changes proposed in this pull request:

- bump instance type to r5.xlarge for logsearch prod archiver vms because all VMs are currently running above 95% memory usage

## security considerations

None
