### PR TITLE
Adding more ephemeral disk for kibana and archiver vms

### DIFF
--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -306,6 +306,8 @@ instance_groups:
   azs: [z1]
   networks:
   - name: services
+  vm_extensions: 
+  - 10GB_ephemeral_disk
   env:
     bosh:
       swap_size: 0
@@ -361,7 +363,10 @@ instance_groups:
   azs: [z1]
   networks:
   - name: services
-  vm_extensions: [logsearch-ingestor-profile]
+  vm_extensions: 
+  - logsearch-ingestor-profile
+  - 10GB_ephemeral_disk
+
 
 - name: ingestor
   jobs:

--- a/logsearch-platform-jobs.yml
+++ b/logsearch-platform-jobs.yml
@@ -218,7 +218,9 @@ instance_groups:
         listen_port: 5600
         proxy_port: 5601
   vm_type: logsearch_kibana
-  vm_extensions: [platform-kibana-lb]
+  vm_extensions: 
+  - platform-kibana-lb
+  - 10GB_ephemeral_disk
   stemcell: default
   azs: [z1]
   networks:


### PR DESCRIPTION
## Changes proposed in this pull request:
- Using the existing 10GB ephemeral vm_extension which already exists, in prod we are getting disk alerts
-
-

## security considerations
None
