### PR TITLE
Switching to larger ephemeral disk size to account for instance swap size

### DIFF
--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -307,7 +307,7 @@ instance_groups:
   networks:
   - name: services
   vm_extensions: 
-  - 10GB_ephemeral_disk
+  - 50GB_ephemeral_disk
   env:
     bosh:
       swap_size: 0
@@ -365,7 +365,7 @@ instance_groups:
   - name: services
   vm_extensions: 
   - logsearch-ingestor-profile
-  - 10GB_ephemeral_disk
+  - 50GB_ephemeral_disk
 
 
 - name: ingestor

--- a/logsearch-platform-jobs.yml
+++ b/logsearch-platform-jobs.yml
@@ -220,7 +220,7 @@ instance_groups:
   vm_type: logsearch_kibana
   vm_extensions: 
   - platform-kibana-lb
-  - 10GB_ephemeral_disk
+  - 50GB_ephemeral_disk
   stemcell: default
   azs: [z1]
   networks:


### PR DESCRIPTION
## Changes proposed in this pull request:
- Previous attempt to expand the disk with 10GB was not successful since the instance sizes ate the disk when creating swap
-
-

## security considerations
none