### PR TITLE
Scale down number of ingestors back now that the platform is caught up

### DIFF
--- a/logsearch-platform-production.yml
+++ b/logsearch-platform-production.yml
@@ -19,6 +19,7 @@ instance_groups:
       oidc_issuer_url: https://opslogin.fr.cloud.gov/oauth/token
 
 - name: ingestor
+  instances: 7
   vm_type: r5.xlarge.logsearch.ingestor
   jobs:
   - name: ingestor_syslog


### PR DESCRIPTION
## Changes proposed in this pull request:
- Scale down number of ingestors back now that the platform is caught up, currently at 10, was 5
-
-

## security considerations
None, cost savings
