### PR TITLE
Update kibana index patterns

### DIFF
--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -175,7 +175,7 @@ instance_groups:
         password: (( grab $CF_PASSWORD ))
       kibana_objects:
         upload_patterns:
-        - {type: index-pattern, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/index-pattern/*.json"}
+        - {type: index-pattern, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/index-pattern/logs-app.json"}
         - {type: search, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/search/app-*.json"}
         - {type: visualization, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/visualization/App-*.json"}
         - {type: dashboard, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/dashboard/App-*.json"}
@@ -306,7 +306,7 @@ instance_groups:
   azs: [z1]
   networks:
   - name: services
-  vm_extensions: 
+  vm_extensions:
   - 50GB_ephemeral_disk
   env:
     bosh:
@@ -363,7 +363,7 @@ instance_groups:
   azs: [z1]
   networks:
   - name: services
-  vm_extensions: 
+  vm_extensions:
   - logsearch-ingestor-profile
   - 50GB_ephemeral_disk
 

--- a/logsearch-platform-jobs.yml
+++ b/logsearch-platform-jobs.yml
@@ -127,7 +127,7 @@ instance_groups:
         host_name: logs-platform
         login_fqdn: opslogin.fr.cloud.gov
         upload_patterns:
-        - {type: index-pattern, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/index-pattern/*.json"}
+        - {type: index-pattern, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/index-pattern/logs-platform.json"}
         - {type: search, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/search/platform-*.json"}
         - {type: visualization, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/visualization/Platform-*.json"}
         - {type: dashboard, pattern: "/var/vcap/jobs/upload-kibana-objects/kibana-objects/dashboard/Platform-*.json"}
@@ -218,7 +218,7 @@ instance_groups:
         listen_port: 5600
         proxy_port: 5601
   vm_type: logsearch_kibana
-  vm_extensions: 
+  vm_extensions:
   - platform-kibana-lb
   - 50GB_ephemeral_disk
   stemcell: default


### PR DESCRIPTION
## Changes proposed in this pull request:

In our tenant logs system, we have three index patterns for people to search logs on:

- `logs-app*`
- `logs-*`
- `logs-platform*`

However, only `logs-app*` makes sense for tenant logs because all the indices for logs there are named as `logs-app-DATE` (e.g. `logs-app-2023-11-02`).

In fact, if you try to use `logs*` or `logs-platform*` to search tenant logs, it doesn't work.

Also, `logs-platform*` is the correct index pattern for platform logs and likewise should be the only index pattern available there.

So this PR updates logs tenant to only have the `logs-app*` index pattern and logs platform to only have the `logs-platform*` index pattern.

## security considerations

None, just updating index patterns available for different log systems
