### PR TITLE
bump max_docvalue_fields_search to 110

### DIFF
--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -149,6 +149,7 @@ instance_groups:
         app_index_settings:
           index.mapping.total_fields.limit: 2000
           index.queries.cache.enabled: "false"
+          index.max_docvalue_fields_search: 110
         base_index_component_name: index-mappings-lfc
         app_index_component_name: index-mappings-app-lfc
         platform_index_component_name: index-mappings-platform-lfc


### PR DESCRIPTION
## Changes proposed in this pull request:

We are getting shard failures in production because there are more than 100 docvalue fields in our indices and the limit is 100 by default. This PR bumps the limit to 110 to give us some headroom.

## security considerations

None, this setting doesn't change any access to logs, just updates a default limit for indices
