### PR TITLE
Split logs and logs-platform snort

### DIFF
--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -35,12 +35,10 @@ instance_groups:
       snort:
         rules:
         - 'alert tcp any any -> any 9200 (msg:"Unexpected logsearch action"; content:"POST"; http_method; content: "logs-app"; http_uri; content:"/_update"; http_uri; classtype:web-application-attack; sid:343080002; rev:1;)'
-        - 'alert tcp any any -> any 9200 (msg:"Unexpected logsearch action"; content:"POST"; http_method; content: "logs-platform"; http_uri; content:"/_update"; http_uri; classtype:web-application-attack; sid:343080003; rev:1;)'
         - 'alert tcp any any -> any 9200 (msg:"Unexpected logsearch action"; content:"DELETE"; http_method; content: "logs-app"; http_uri; classtype:web-application-attack; sid:343080004; rev:1;)'
-        - 'alert tcp any any -> any 9200 (msg:"Unexpected logsearch action"; content:"DELETE"; http_method; content: "logs-platform"; http_uri; classtype:web-application-attack; sid:343080005; rev:1;)'
         - (( concat "suppress gen_id 1, sig_id 343080004, track by_src, ip " instance_groups.maintenance.networks.services.static_ips.[0] ))
-        - 'alert tcp any any -> any 9200 (msg:"Unexpected logsearch action"; content:"DELETE"; http_method; content: "logs-platform"; http_uri; classtype:web-application-attack; sid:343080005; rev:1;)'
-        - (( concat "suppress gen_id 1, sig_id 343080005, track by_src, ip " instance_groups.maintenance.networks.services.static_ips.[0] ))
+        - 'suppress gen_id 1, sig_id 343080004, track by_src, ip 127.0.0.1'
+
   persistent_disk_type: logsearch_es_master
   stemcell: default
   azs: [z1]

--- a/logsearch-platform-jobs.yml
+++ b/logsearch-platform-jobs.yml
@@ -27,6 +27,15 @@ instance_groups:
           delay_allocation_restart: "15m"
         jvm_options:
           - "-Dlog4j2.formatMsgNoLookups=true"
+  - name: snort-config
+    release: snort
+    properties:
+      snort:
+        rules:
+        - 'alert tcp any any -> any 9200 (msg:"Unexpected logsearch action"; content:"POST"; http_method; content: "logs-platform"; http_uri; content:"/_update"; http_uri; classtype:web-application-attack; sid:343080003; rev:1;)'
+        - 'alert tcp any any -> any 9200 (msg:"Unexpected logsearch action"; content:"DELETE"; http_method; content: "logs-platform"; http_uri; classtype:web-application-attack; sid:343080005; rev:1;)'
+        - (( concat "suppress gen_id 1, sig_id 343080005, track by_src, ip " instance_groups.maintenance.networks.services.static_ips.[0] ))
+        - 'suppress gen_id 1, sig_id 343080005, track by_src, ip 127.0.0.1'
   vm_type: logsearch_es_master
   persistent_disk_type: logsearch_es_master
   stemcell: default


### PR DESCRIPTION
## Changes proposed in this pull request:
- Split the snort alerts between logs and logs-platform
- Suppress false positives from maintenance node on localhost on 9200
-

## security considerations
Adds custom snort alerts to logs-platform
