### PR TITLE
Use static ip for maintenance node

### DIFF
--- a/logsearch-platform-jobs.yml
+++ b/logsearch-platform-jobs.yml
@@ -145,6 +145,8 @@ instance_groups:
   azs: [z1]
   networks:
   - name: services
+    static_ips:
+    - (( grab terraform_outputs.logsearch_static_ips.[6] ))
   update:
     serial: true # Block on this job to create deploy group 1
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Switch to using static ip for maintenance node on logs platform so the ip address can be used for the snort rules
-
-

## security considerations
IP addresses stored in runtime config
