### PR TITLE
Switch to jammy-snort release

### DIFF
--- a/logsearch-deployment.yml
+++ b/logsearch-deployment.yml
@@ -20,6 +20,5 @@ releases:
 - {name: routing, version: latest}
 - {name: bosh-dns-aliases, version: latest}
 - {name: bosh-dns, version: latest}
-- {name: snort, version: latest}
 - {name: cron, version: latest}
 - {name: bpm, version: latest}

--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -30,7 +30,7 @@ instance_groups:
         config_options:
           indices.query.bool.max_clause_count: 2048
   - name: snort-config
-    release: snort
+    release: jammy-snort
     properties:
       snort:
         rules:

--- a/logsearch-platform-jobs.yml
+++ b/logsearch-platform-jobs.yml
@@ -28,7 +28,7 @@ instance_groups:
         jvm_options:
           - "-Dlog4j2.formatMsgNoLookups=true"
   - name: snort-config
-    release: snort
+    release: jammy-snort
     properties:
       snort:
         rules:


### PR DESCRIPTION
## Changes proposed in this pull request:
- Switch to jammy-snort bosh release for the snort config to retire the older snort bosh release
-
-

## security considerations
None
