### PR TITLE
Suppressing false positive snort

### DIFF
--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -38,7 +38,8 @@ instance_groups:
         - 'alert tcp any any -> any 9200 (msg:"Unexpected logsearch action"; content:"DELETE"; http_method; content: "logs-app"; http_uri; classtype:web-application-attack; sid:343080004; rev:1;)'
         - (( concat "suppress gen_id 1, sig_id 343080004, track by_src, ip " instance_groups.maintenance.networks.services.static_ips.[0] ))
         - 'suppress gen_id 1, sig_id 343080004, track by_src, ip 127.0.0.1'
-
+        - 'suppress gen_id 1, sid_id 57907, track by_src, ip 127.0.0.1'
+        
   persistent_disk_type: logsearch_es_master
   stemcell: default
   azs: [z1]

--- a/logsearch-platform-jobs.yml
+++ b/logsearch-platform-jobs.yml
@@ -36,6 +36,8 @@ instance_groups:
         - 'alert tcp any any -> any 9200 (msg:"Unexpected logsearch action"; content:"DELETE"; http_method; content: "logs-platform"; http_uri; classtype:web-application-attack; sid:343080005; rev:1;)'
         - (( concat "suppress gen_id 1, sig_id 343080005, track by_src, ip " instance_groups.maintenance.networks.services.static_ips.[0] ))
         - 'suppress gen_id 1, sig_id 343080005, track by_src, ip 127.0.0.1'
+        - 'suppress gen_id 1, sid_id 57907, track by_src, ip 127.0.0.1'
+        
   vm_type: logsearch_es_master
   persistent_disk_type: logsearch_es_master
   stemcell: default


### PR DESCRIPTION
## Changes proposed in this pull request:
- Suppressing false positive alert coming from admin actions from the ingestor nodes, external ips will still alert.
-
-

## security considerations
Reduce the number of false positive alerts needing investigation
