### PR TITLE
Suppress false alert snort messages

### DIFF
--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -39,7 +39,8 @@ instance_groups:
         - (( concat "suppress gen_id 1, sig_id 343080004, track by_src, ip " instance_groups.maintenance.networks.services.static_ips.[0] ))
         - 'suppress gen_id 1, sig_id 343080004, track by_src, ip 127.0.0.1'
         - 'suppress gen_id 1, sig_id 57907, track by_src, ip 127.0.0.1'
-
+        - 'suppress gen_id 1, sig_id 26275, track by_src, ip 127.0.0.1'
+        
   persistent_disk_type: logsearch_es_master
   stemcell: default
   azs: [z1]

--- a/logsearch-platform-jobs.yml
+++ b/logsearch-platform-jobs.yml
@@ -37,6 +37,7 @@ instance_groups:
         - (( concat "suppress gen_id 1, sig_id 343080005, track by_src, ip " instance_groups.maintenance.networks.services.static_ips.[0] ))
         - 'suppress gen_id 1, sig_id 343080005, track by_src, ip 127.0.0.1'
         - 'suppress gen_id 1, sig_id 57907, track by_src, ip 127.0.0.1'
+        - 'suppress gen_id 1, sig_id 26275, track by_src, ip 127.0.0.1'
 
   vm_type: logsearch_es_master
   persistent_disk_type: logsearch_es_master


### PR DESCRIPTION
## Changes proposed in this pull request:
- After investigation determined these were normal maintenance traffic, still going to alert if the rule is hit from an external ip
-
-

## security considerations
Suppressing false snort alert
