### PR TITLE
update instance type for dev data nodes from t3.large to m6i.large

### DIFF
--- a/logsearch-development.yml
+++ b/logsearch-development.yml
@@ -10,7 +10,7 @@ instance_groups:
 
 - name: elasticsearch_data
   instances: 3
-  vm_type: t3.large
+  vm_type: m6i.large
 
 - name: maintenance
   vm_type: t3.medium


### PR DESCRIPTION
## Changes proposed in this pull request:

Reincarnation of #346 . Turns out we do need more memory for these data nodes because they are still periodically crashing

## security considerations

None
