### PR TITLE
Add another data node to log prod

### DIFF
--- a/logsearch-production.yml
+++ b/logsearch-production.yml
@@ -3,6 +3,7 @@ instance_groups:
   vm_type: m6i.xlarge
 
 - name: elasticsearch_data
+  instances: 12
   vm_type: r6i.2xlarge
   update:
     max_in_flight: 2


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add a 12th data node to production logsearch, getting prometheus storage alerts for node 10, plus fire season is coming up
- Story: https://github.com/cloud-gov/product/issues/3014
-

## security considerations
None
