### PR TITLE
increase index.max_docvalue_fields_search from 300 to 400

### DIFF
--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -145,7 +145,7 @@ instance_groups:
             app_index_settings:
               index.mapping.total_fields.limit: 2000
               index.queries.cache.enabled: "false"
-              index.max_docvalue_fields_search: 300
+              index.max_docvalue_fields_search: 400
             base_index_component_name: index-mappings-lfc
             app_index_component_name: index-mappings-app-lfc
             platform_index_component_name: index-mappings-platform-lfc


### PR DESCRIPTION
## Changes proposed in this pull request:

Necessary to fix observed errors in Logsearch:

```
Trying to retrieve too many docvalue_fields. Must be less than or equal to: [300] but was [373]. This limit can be set by changing the [index.max_docvalue_fields_search] index level setting
```

## security considerations

Should be no security impact, just increase limit to address error
