### PR TITLE
increase index.max_docvalue_fields_search index setting to 500

### DIFF
--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -145,7 +145,7 @@ instance_groups:
             app_index_settings:
               index.mapping.total_fields.limit: 2000
               index.queries.cache.enabled: "false"
-              index.max_docvalue_fields_search: 400
+              index.max_docvalue_fields_search: 500
             base_index_component_name: index-mappings-lfc
             app_index_component_name: index-mappings-app-lfc
             platform_index_component_name: index-mappings-platform-lfc


### PR DESCRIPTION
## Changes proposed in this pull request:

Necessary to fix observed errors in Logsearch:

```
Trying to retrieve too many docvalue_fields. Must be less than or equal to: [400] but was [445]. This limit can be set by changing the [index.max_docvalue_fields_search] index level setting
```

We did previously have to increase this value in #371 

[This behavior seems symptomatic of a bug in Kibana which is apparently resolved in version 7.11](https://github.com/elastic/kibana/issues/22897#issuecomment-738081829), but we can't update to that version due to the license changes.

## security considerations

Should be no security impact, just increase limit to address error
