### PR TITLE
Add blocking of traffic caused by snort rule 58741

### DIFF
--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -41,6 +41,9 @@ instance_groups:
               - 'suppress gen_id 1, sig_id 57907, track by_src, ip 127.0.0.1'
               - 'suppress gen_id 1, sig_id 26275, track by_src, ip 127.0.0.1'
               - 'suppress gen_id 1, sig_id 41495, track by_src, ip 127.0.0.1'
+              - 'suppress gen_id 1, sig_id 58741'
+              - 'drop tcp $EXTERNAL_NET any -> $HOME_NET $HTTP_PORTS (msg:"SERVER-OTHER Apache Log4j logging remote code execution attempt"; flow:to_server,established; content:"${"; fast_pattern:only; http_client_body; pcre:"/\x24\x7b.{0,200}(%(25)?24|\x24)(%(25)?7b|\x7b).{0,200}(%(25)?3a|\x3a)(%(25)?(27|2d|5c|22)|[\x27\x2d\x5c\x22])*([jndi\x7d\x3a\x2d]|(%(25)?(7d|3a|2d))|(%(25)?5c|\x5c)u00[a-f0-9]{2}){1,4}(%(25)?(22|27)|[\x22\x27])?(%(25)?(3a|7d)|[\x3a\x7djndi])/Pi"; metadata:policy balanced-ips drop, policy connectivity-ips drop, policy max-detect-ips drop, policy security-ips drop, ruleset community, service http; reference:cve,2021-44228; reference:cve,2021-44832; reference:cve,2021-45046; reference:cve,2021-45105; classtype:attempted-user; sid:58741000; rev:6;)'
+
     persistent_disk_type: logsearch_es_master
     stemcell: default
     azs: [z1]

--- a/logsearch-platform-jobs.yml
+++ b/logsearch-platform-jobs.yml
@@ -39,6 +39,9 @@ instance_groups:
               - 'suppress gen_id 1, sig_id 57907, track by_src, ip 127.0.0.1'
               - 'suppress gen_id 1, sig_id 26275, track by_src, ip 127.0.0.1'
               - 'suppress gen_id 1, sig_id 41495, track by_src, ip 127.0.0.1'
+              - 'suppress gen_id 1, sig_id 58741'
+              - 'drop tcp $EXTERNAL_NET any -> $HOME_NET $HTTP_PORTS (msg:"SERVER-OTHER Apache Log4j logging remote code execution attempt"; flow:to_server,established; content:"${"; fast_pattern:only; http_client_body; pcre:"/\x24\x7b.{0,200}(%(25)?24|\x24)(%(25)?7b|\x7b).{0,200}(%(25)?3a|\x3a)(%(25)?(27|2d|5c|22)|[\x27\x2d\x5c\x22])*([jndi\x7d\x3a\x2d]|(%(25)?(7d|3a|2d))|(%(25)?5c|\x5c)u00[a-f0-9]{2}){1,4}(%(25)?(22|27)|[\x22\x27])?(%(25)?(3a|7d)|[\x3a\x7djndi])/Pi"; metadata:policy balanced-ips drop, policy connectivity-ips drop, policy max-detect-ips drop, policy security-ips drop, ruleset community, service http; reference:cve,2021-44228; reference:cve,2021-44832; reference:cve,2021-45046; reference:cve,2021-45105; classtype:attempted-user; sid:58741000; rev:6;)'
+
     vm_type: logsearch_es_master
     persistent_disk_type: logsearch_es_master
     stemcell: default


### PR DESCRIPTION
## Changes proposed in this pull request:
- Second time we've received an alert in the last 6 months for this, just going to block the traffic based on this rule instead of alerting and investigating
- Mutes the existing `alert` rule and adds a `drop` rule with a unique identifier which is the original rule number with 3 zeroes appended to keep it out of the number sequences assigned by snort maintainers: 58741000
-

## security considerations
Blocks traffic instead of simply alerting
