### PR TITLE
remove value metrics from ingestion 

### DIFF
--- a/logsearch-jobs.yml
+++ b/logsearch-jobs.yml
@@ -168,7 +168,6 @@ instance_groups:
             firehose_events:
               - LogMessage
               - ContainerMetric
-              - ValueMetric
             system_domain: (( grab $CF_SYSTEM_DOMAIN ))
             user: (( grab $CF_USERNAME ))
             password: (( grab $CF_PASSWORD ))


### PR DESCRIPTION
## Changes proposed in this pull request:

Reverts https://github.com/cloud-gov/cg-deploy-logsearch/pull/374

This PR excludes `ValueMetric` logs (including `cpu_entitlement`) from ingestion since they do not have org/space/app metadata so they cannot meaningfully be used or queried by users. Since these metrics aren't useful to users without the additional metadata, we should exclude them and avoid the cost of ingesting and storing them.

## security considerations

None, just removing unhelpful metrics from ingestion
