### PR TITLE
Bump timeout since warm are sloooow

### DIFF
--- a/logsearch-platform-jobs.yml
+++ b/logsearch-platform-jobs.yml
@@ -187,7 +187,7 @@ instance_groups:
             limits:
               fd: 131072 # 2 ** 17
             health:
-              timeout: 900
+              timeout: 1500
             recovery:
               delay_allocation_restart: "15m"
             config_options: {"xpack.monitoring.enabled": false}
@@ -217,7 +217,7 @@ instance_groups:
             limits:
               fd: 131072 # 2 ** 17
             health:
-              timeout: 900
+              timeout: 1500
             recovery:
               delay_allocation_restart: "15m"
             config_options: {"xpack.monitoring.enabled": false}


### PR DESCRIPTION
## Changes proposed in this pull request:
- warm take longer to come up so data nodes need more time to finish confirming sshards
-
-

## security considerations
None